### PR TITLE
Added a json body parser size limit as a config option

### DIFF
--- a/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks.plugin.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/cloud-tasks.plugin.ts
@@ -16,7 +16,12 @@ import { CloudTaskOptions, ROUTE } from './types';
       CloudTasksPlugin.options
     );
     config.apiOptions.middleware = [
-      { route: `/${ROUTE}`, handler: json() },
+      {
+        route: `/${ROUTE}`,
+        handler: json({
+          limit: CloudTasksPlugin.options.bodySizeLimit || '1mb',
+        }),
+      },
       ...config.apiOptions.middleware,
     ];
     return config;

--- a/packages/vendure-plugin-google-cloud-tasks/src/types.ts
+++ b/packages/vendure-plugin-google-cloud-tasks/src/types.ts
@@ -7,6 +7,10 @@ export interface CloudTaskOptions {
    * Optional suffix, I.E. for differentiating between test, acc and prod queues
    */
   queueSuffix?: string;
+  /**
+   * Optional size limit to be passed to `body-parser/json`
+   */
+  bodySizeLimit?: string;
 }
 
 export interface CloudTaskMessage {


### PR DESCRIPTION
This PR adds a config option to the google cloud tasks plugin. The config option controls the body size for the JSON body parser. I'm quite sure that cloud tasks can handle larger payloads than the default size limit setting.